### PR TITLE
3D Secure Hook for Existing SagePay Implementation

### DIFF
--- a/spec/models/spree/gateway/adyen_payment_encrypted_spec.rb
+++ b/spec/models/spree/gateway/adyen_payment_encrypted_spec.rb
@@ -8,6 +8,26 @@ module Spree
       res
     end
 
+    let(:three_d_secure_response) do
+      res = double(
+        'Response',
+        psp_reference: 'psp',
+        result_code: 'rejected',
+        authorised?: false,
+        redirect_shopper?: true,
+        md: '123',
+        issuer_url: 'https://3d-secure.com/secure',
+        pa_request: ''
+      )
+
+      allow(res).to receive(:[]).with('refusal_reason').and_return(nil)
+      allow(res).to receive(:[]).with('md').and_return(res.md)
+      allow(res).to receive(:[]).with('issuer_url').and_return(res.issuer_url)
+      allow(res).to receive(:[]).with('pa_request').and_return(res.pa_request)
+
+      res
+    end
+
     let(:credit_card) do
       cc = create(:credit_card, last_digits: nil, encrypted_data: 'encrypted_card_data')
       cc.payments << create(:payment, amount: 30000, state: 'checkout')
@@ -21,8 +41,57 @@ module Spree
         browser_info = { browser_info: { accept_header: 'accept', user_agent: 'agent' } }
         expect(subject.provider).to receive(:authorise_payment).with(hash_including(browser_info)).and_return(response)
 
-        result = subject.authorize(30000, credit_card, request_env: { 'HTTP_ACCEPT' => 'accept', 'HTTP_USER_AGENT' => 'agent' })
+        result = subject.purchase(30000, credit_card, request_env: { 'HTTP_ACCEPT' => 'accept', 'HTTP_USER_AGENT' => 'agent' })
 
+        expect(result.authorization).to eq response.psp_reference
+        expect(result.cvv_result['code']).to eq response.result_code
+      end
+    end
+
+    context '3D Secure authorisation required' do
+      it 'returns a 3D Secure response for 3D Secure enabled cards' do
+        browser_info = { browser_info: { accept_header: 'accept', user_agent: 'agent' } }
+        expect(subject.provider).to receive(:authorise_payment).with(hash_including(browser_info)).and_return(three_d_secure_response)
+
+        result = subject.purchase(30000, credit_card, request_env: { 'HTTP_ACCEPT' => 'accept', 'HTTP_USER_AGENT' => 'agent' })
+
+        expect(result.success?).to be_falsey
+
+        expect(result['md']).to eq three_d_secure_response.md
+        expect(result['issuer_url']).to eq three_d_secure_response.issuer_url
+        expect(result['pa_request']).to eq three_d_secure_response.pa_request
+
+        expect(result.authorization).to eq three_d_secure_response.psp_reference
+        expect(result.cvv_result['code']).to eq three_d_secure_response.result_code
+      end
+    end
+
+    context '3D Secure authenticated, final authorisation required' do
+      it 'successfully authorises the payment' do
+        expect_any_instance_of(Spree::Payment).to receive(:md?).and_return(true)
+        expect_any_instance_of(Spree::Payment).to receive(:md).and_return('123')
+
+        expect(subject.provider).to receive(:authorise_payment_3dsecure).with(
+          hash_including(
+            md: '123',
+            pa_response: 'pa_response',
+            shopper_ip: '127.0.0.1',
+            browser_info: {
+              accept_header: 'accept',
+              user_agent: 'agent'
+            }
+          )
+        ).and_return(response)
+
+        gateway_options = {
+          pa_response: 'pa_response',
+          ip: '127.0.0.1',
+          request_env: { 'HTTP_ACCEPT' => 'accept', 'HTTP_USER_AGENT' => 'agent' }
+        }
+
+        result = subject.purchase(30000, credit_card, gateway_options)
+
+        expect(result.success?).to be_truthy
         expect(result.authorization).to eq response.psp_reference
         expect(result.cvv_result['code']).to eq response.result_code
       end
@@ -50,12 +119,12 @@ module Spree
 
       it "adds processing api calls to response object" do
         expect {
-          subject.authorize(30000, credit_card, gateway_options)
+          subject.purchase(30000, credit_card, gateway_options)
         }.not_to raise_error
 
         credit_card.gateway_customer_profile_id = "123"
         expect {
-          subject.authorize(30000, credit_card, gateway_options)
+          subject.purchase(30000, credit_card, gateway_options)
         }.not_to raise_error
       end
 
@@ -64,14 +133,14 @@ module Spree
         gateway_options[:customer_id] = nil
 
         expect {
-          subject.authorize(30000, credit_card, gateway_options)
+          subject.purchase(30000, credit_card, gateway_options)
         }.not_to raise_error
       end
     end
 
     context "refused" do
       let(:response) do
-        res = double("Response", authorised?: false, result_code: "Refused", refusal_reason: "010 Not allowed")
+        res = double("Response", authorised?: false, redirect_shopper?: false, result_code: "Refused", refusal_reason: "010 Not allowed")
         allow(res).to receive(:[]).with('refusal_reason').and_return(res.refusal_reason)
         res
       end
@@ -81,7 +150,7 @@ module Spree
       end
 
       it "response obj print friendly message" do
-        result = subject.authorize(30000, credit_card, request_env: {})
+        result = subject.purchase(30000, credit_card, request_env: {})
         expect(result.to_s).to include(response.refusal_reason)
       end
     end
@@ -182,7 +251,7 @@ module Spree
 
       it "adds processing api calls to response object" do
         expect(subject.provider).to receive(:authorise_one_click_payment).and_return response
-        result = subject.authorize(30000, credit_card, request_env: {})
+        result = subject.purchase(30000, credit_card, request_env: {})
       end
     end
 


### PR DESCRIPTION
:warning: **This is based off of #1 for a nicer diff** :warning:

This re-implements 3D Secure to work with our existing 3DS code:
1. If a standard payment authorisation returns a 3D Secure response, it is returned from the gateway so that the Spree processing code (`handle_response`) can take over
2. The storefront takes care of the 3D Secure authorisation
3. Re-processing the payment with an added MD and PaReq (returned from the 3DS provider) will perform a 3DS authorisation with Adyen
